### PR TITLE
feat: add support for native enum types

### DIFF
--- a/src/openapi/zod-to-openapi.test.ts
+++ b/src/openapi/zod-to-openapi.test.ts
@@ -136,6 +136,21 @@ it('should serialize enums', () => {
   })
 })
 
+it('should serialize native enums', () => {
+  enum NativeEnum {
+    ADAMA = 'adama',
+    KOTA = 'kota',
+  }
+
+  const schema = z.nativeEnum(NativeEnum)
+  const openApiObject = zodToOpenAPI(schema)
+
+  expect(openApiObject).toEqual({
+    type: 'string',
+    enum: ['adama', 'kota'],
+  })
+})
+
 describe('scalar types', () => {
   const testCases: [ZodTypeAny, string, string?][] = [
     // [zod type, expected open api type, expected format]

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -11,6 +11,7 @@ import {
   ZodEnum,
   ZodIntersection,
   ZodLiteral,
+  ZodNativeEnum,
   ZodNullable,
   ZodNumber,
   ZodObject,
@@ -176,6 +177,13 @@ export function zodToOpenAPI(zodType: ZodTypeAny) {
     const { values } = zodType._def
     object.type = 'string'
     object.enum = values
+  }
+
+  if (is(zodType, ZodNativeEnum)) {
+    const { values } = zodType._def
+    // this only supports enums with string literal values
+    object.type = 'string'
+    object.enum = Object.values(values)
   }
 
   if (is(zodType, ZodTransformer)) {


### PR DESCRIPTION
The `zodToOpenAPI` method did not support zod's [Native enum](https://github.com/colinhacks/zod#native-enums) option