### PR TITLE
fix: support partial objects

### DIFF
--- a/src/openapi/zod-to-openapi.test.ts
+++ b/src/openapi/zod-to-openapi.test.ts
@@ -105,6 +105,28 @@ it('should serialize objects', () => {
   })
 })
 
+it('should serialize partial objects', () => {
+  const schema = z
+    .object({
+      prop1: z.string(),
+      prop2: z.string(),
+    })
+    .partial()
+  const openApiObject = zodToOpenAPI(schema)
+
+  expect(openApiObject).toEqual({
+    type: 'object',
+    properties: {
+      prop1: {
+        type: 'string',
+      },
+      prop2: {
+        type: 'string',
+      },
+    },
+  })
+})
+
 it('should serialize nullable types', () => {
   const schema = z.string().nullable()
   const openApiObject = zodToOpenAPI(schema)

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -222,10 +222,7 @@ export function zodToOpenAPI(zodType: ZodTypeAny) {
       if (!isOptional) object.required.push(key)
     }
 
-    if (
-      Object.keys(object.properties).length > 0 &&
-      object.required.length === 0
-    ) {
+    if (object.required.length === 0) {
       delete object.required
     }
   }

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -221,6 +221,13 @@ export function zodToOpenAPI(zodType: ZodTypeAny) {
       const isOptional = optionalTypes.includes(schema.constructor.name)
       if (!isOptional) object.required.push(key)
     }
+
+    if (
+      Object.keys(object.properties).length > 0 &&
+      object.required.length === 0
+    ) {
+      delete object.required
+    }
   }
 
   if (is(zodType, ZodRecord)) {


### PR DESCRIPTION
Pretty simple fix here to avoid generating an invalid OpenAPI schema if the object is partial (and thus has no required fields)

According to the JSON Schema spec (which the OpenAPI schema extends) if the `required` property is provided for a value of type `object` then it [must be an array of at least 1 item](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.15)

This change will remove the `required` property in the case that it is empty after all the properties have been iterated through