### PR TITLE
feat: ✨ added support for `ZodEffects` ans `ZodLazy` in `zodToOpenAPI`

### DIFF
--- a/src/openapi/patch.ts
+++ b/src/openapi/patch.ts
@@ -12,6 +12,8 @@ function getSchemaObjectFactory(): Type<SchemaObjectFactoryClass> {
     .SchemaObjectFactory
 }
 
+let done: string[] = []
+
 export function patchNestJsSwagger(
   SchemaObjectFactory = getSchemaObjectFactory()
 ) {
@@ -25,6 +27,10 @@ export function patchNestJsSwagger(
       schemas,
       schemaRefsStack
     ) {
+      if (done.includes(type.name)) {
+        return type.name
+      }
+
       if (this['isLazyTypeFunc'](type)) {
         const factory = type as () => Type<unknown>
         type = factory()
@@ -35,7 +41,7 @@ export function patchNestJsSwagger(
       }
 
       schemas[type.name] = zodToOpenAPI(type.schema)
-
+      done = [...done, type.name]
       return type.name
     }
 

--- a/src/openapi/zod-to-openapi.test.ts
+++ b/src/openapi/zod-to-openapi.test.ts
@@ -60,6 +60,18 @@ const overrideIntersectionSchema = z.intersection(
   })
 )
 
+const transformedSchema = z
+  .object({
+    seconds: z.number(),
+  })
+  .transform((value) => ({
+    seconds: value.seconds,
+    minutes: value.seconds / 60,
+    hours: value.seconds / 3600,
+  }))
+
+const lazySchema = z.lazy(() => z.string())
+
 it('should serialize a complex schema', () => {
   const openApiObject = zodToOpenAPI(complexTestSchema)
 
@@ -195,4 +207,26 @@ describe('scalar types', () => {
       })
     })
   }
+})
+
+it('should serialize transformed schema', () => {
+  const openApiObject = zodToOpenAPI(transformedSchema)
+
+  expect(openApiObject).toEqual({
+    type: 'object',
+    required: ['seconds'],
+    properties: {
+      seconds: {
+        type: 'number',
+      },
+    },
+  })
+})
+
+it('should serialize lazy schema', () => {
+  const openApiObject = zodToOpenAPI(lazySchema)
+
+  expect(openApiObject).toEqual({
+    type: 'string',
+  })
 })

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -8,8 +8,10 @@ import {
   ZodDateString,
   ZodDefault,
   ZodDiscriminatedUnion,
+  ZodEffects,
   ZodEnum,
   ZodIntersection,
+  ZodLazy,
   ZodLiteral,
   ZodNativeEnum,
   ZodNullable,
@@ -237,6 +239,16 @@ export function zodToOpenAPI(zodType: ZodTypeAny) {
     const { left, right } = zodType._def
     const merged = mergeDeep(zodToOpenAPI(left), zodToOpenAPI(right))
     Object.assign(object, merged)
+  }
+
+  if (is(zodType, ZodEffects)) {
+    const { schema } = zodType._def
+    Object.assign(object, zodToOpenAPI(schema))
+  }
+
+  if (is(zodType, ZodLazy)) {
+    const { getter } = zodType._def
+    Object.assign(object, zodToOpenAPI(getter()))
   }
 
   return object

--- a/src/openapi/zod-to-openapi.ts
+++ b/src/openapi/zod-to-openapi.ts
@@ -32,7 +32,7 @@ export function is<T extends Type<ZodTypeAny>>(
   input: ZodTypeAny,
   factory: T
 ): input is InstanceType<T> {
-  return factory.name === input.constructor.name
+  return factory.name === input._def.typeName
 }
 export function zodToOpenAPI(zodType: ZodTypeAny) {
   const object: SchemaObject = {}


### PR DESCRIPTION
# Features:

Support for `ZodEffects` ans `ZodLazy` in `zodToOpenAPI`.

`ZodEffect` will only care about the input type, `ZodLazy` unwraps the definition before recursing.

# Fixes

`DTOs` were registered multiple times when calling the patch, added a check if schema has already been validated.

`is` function in `src/openapi/zod-to-openapi.ts` was not matching zod types: replaced `input.constructor.name` with `input._def.typeName`