### PR TITLE
Added APP_PIPE import to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ When the data is invalid - it throws [ZodValidationException](#validation-except
 
 ```ts
 import { ZodValidationPipe } from 'nestjs-zod'
+import { APP_PIPE } from '@nestjs/core'
 
 @Module({
   providers: [


### PR DESCRIPTION
It is not clear that APP_PIPE is imported from `@nestjs/core`, before using this, I have used class validator which does not use the APP_PIPE import.