### PR TITLE
fix: fix `validate` function to return the correct type

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,10 +1,14 @@
-import { ZodSchema } from 'zod'
+import { ZodSchema, ZodTypeDef } from 'zod'
 import { isZodDto, ZodDto } from './dto'
 import { createZodValidationException, ZodExceptionCreator } from './exception'
 
-export function validate(
+export function validate<
+  TOutput = any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  TDef extends ZodTypeDef = ZodTypeDef,
+  TInput = TOutput
+>(
   value: unknown,
-  schemaOrDto: ZodSchema | ZodDto,
+  schemaOrDto: ZodSchema<TOutput, TDef, TInput> | ZodDto<TOutput, TDef, TInput>,
   createValidationException: ZodExceptionCreator = createZodValidationException
 ) {
   const schema = isZodDto(schemaOrDto) ? schemaOrDto.schema : schemaOrDto


### PR DESCRIPTION
The `validate` function is currently returning `any`. These changes fix it to return the correct type, which is based on the passed schema.