### PR TITLE
feat: upgrade to support zod 3.21.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@nestjs/common": ">= 8.0.0",
     "@nestjs/core": ">= 8.0.0",
     "@nestjs/swagger": ">= 5.0.0",
-    "zod": ">= 3.21.4"
+    "zod": ">= 3.14.3"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/package.json
+++ b/package.json
@@ -61,13 +61,13 @@
     "rxjs": "^7.5.5",
     "ts-jest": "^28.0.2",
     "typescript": "4.6.3",
-    "zod": "3.14.3"
+    "zod": "3.21.4"
   },
   "peerDependencies": {
     "@nestjs/common": ">= 8.0.0",
     "@nestjs/core": ">= 8.0.0",
     "@nestjs/swagger": ">= 5.0.0",
-    "zod": ">= 3.14.3"
+    "zod": ">= 3.21.4"
   },
   "peerDependenciesMeta": {
     "@nestjs/common": {

--- a/src/z/issues/overrided.ts
+++ b/src/z/issues/overrided.ts
@@ -10,20 +10,22 @@ export type ZodMinMaxValueType =
   | 'array'
   | 'string'
   | 'number'
+  | 'bigint'
   | 'set'
   | 'date_string_year'
+  | 'date'
   | 'password'
 
 export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small
-  minimum: number
+  minimum: number | bigint
   inclusive: boolean
   type: ZodMinMaxValueType
 }
 
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big
-  maximum: number
+  maximum: number | bigint
   inclusive: boolean
   type: ZodMinMaxValueType
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4868,7 +4868,7 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-zod@3.14.3:
-  version "3.14.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.14.3.tgz#60e86341c05883c281fe96a0e79acea48a09f123"
-  integrity sha512-OzwRCSXB1+/8F6w6HkYHdbuWysYWnAF4fkRgKDcSFc54CE+Sv0rHXKfeNUReGCrHukm1LNpi6AYeXotznhYJbQ==
+zod@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==


### PR DESCRIPTION
back again @risenforces!

I was playing around with using an upgraded version of `zod` to see how compatible it would be with this library and I started to trigger a stack overflow when trying to convert a schema that used the `z.json()` helper since it's recursive and so the parsing loops forever (not sure what stops that with the previous version of `zod`)

I was able to solve this for now by keeping track of the lazy nodes that have been visited to avoid cycles

this one I'm a bit less sure about so I'd appreciate some feedback if you feel there's a better approach or if supporting the latest versions of `zod` will be more complicated than the solution I've provided.

here's an MVP of a the failure case with the latest version of `nestjs-zod` and the latest version of `zod` (`v3.21.4`)

```
import { z } from 'nestjs-zod/z';
import { zodToOpenAPI } from 'nestjs-zod';

const schema = z.object({
  z: z.json(),
});

const x = zodToOpenAPI(schema);
```