### PR TITLE
Pass on `this` when calling defaultExplore

### DIFF
--- a/src/openapi/patch.ts
+++ b/src/openapi/patch.ts
@@ -31,7 +31,7 @@ export function patchNestJsSwagger(
       }
 
       if (!isZodDto(type)) {
-        return defaultExplore(type, schemas, schemaRefsStack)
+        return defaultExplore.call(this, type, schemas, schemaRefsStack)
       }
 
       schemas[type.name] = zodToOpenAPI(type.schema)


### PR DESCRIPTION
When using zod based DTOs in combination with regular NestJS DTOs, the following error was thrown:

```
TypeError: Cannot read properties of undefined (reading 'isLazyTypeFunc')
```

It seems like the call to `defaultExplore` inside `patchNestJsSwagger` is not passing on `this` properly. After looking at the original source for this (https://github.com/anatine/zod-plugins/blob/main/packages/zod-nestjs/src/lib/patch-nest-swagger.ts) I changed it to this, which seems to have solved the issue.