### PR TITLE
feat: zod serializer interceptor

### DIFF
--- a/src/serializer.test.ts
+++ b/src/serializer.test.ts
@@ -1,0 +1,57 @@
+import { createMock } from '@golevelup/ts-jest'
+import { CallHandler, ExecutionContext } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { lastValueFrom, of } from 'rxjs'
+import { z } from 'zod'
+import { createZodDto } from './dto'
+import { ZodSerializerInterceptor } from './serializer'
+
+describe('ZodSerializerInterceptor', () => {
+  const UserSchema = z.object({
+    username: z.string(),
+  })
+
+  class UserDto extends createZodDto(UserSchema) {}
+
+  const testUser = {
+    username: 'test',
+    password: 'test',
+  }
+
+  const context = createMock<ExecutionContext>()
+  const handler = createMock<CallHandler>({
+    handle: () => of(testUser),
+  })
+
+  test('interceptor should strip out password', async () => {
+    const reflector = createMock<Reflector>({
+      getAllAndOverride: () => UserDto,
+    })
+
+    const interceptor = new ZodSerializerInterceptor(reflector)
+
+    const userObservable = interceptor.intercept(context, handler)
+    const user: typeof testUser = await lastValueFrom(userObservable)
+
+    expect(user.password).toBe(undefined)
+    expect(user.username).toBe('test')
+  })
+
+  test('interceptor should not strip out password if no UserDto is defined', async () => {
+    const context = createMock<ExecutionContext>()
+    const handler = createMock<CallHandler>({
+      handle: () => of(testUser),
+    })
+    const reflector = createMock<Reflector>({
+      getAllAndOverride: jest.fn(),
+    })
+
+    const interceptor = new ZodSerializerInterceptor(reflector)
+
+    const userObservable = interceptor.intercept(context, handler)
+    const user: typeof testUser = await lastValueFrom(userObservable)
+
+    expect(user.password).toBe('test')
+    expect(user.username).toBe('test')
+  })
+})

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -1,0 +1,52 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  Injectable,
+  NestInterceptor,
+  SetMetadata,
+  StreamableFile,
+} from '@nestjs/common'
+import { map, Observable } from 'rxjs'
+import { ZodSchema } from 'zod'
+import { ZodDto } from './dto'
+import { validate } from './validate'
+
+// NOTE (external)
+// We need to deduplicate them here due to the circular dependency
+// between core and common packages
+const REFLECTOR = 'Reflector'
+
+export const ZodSerializerDtoOptions = 'ZOD_SERIALIZER_DTO_OPTIONS' as const
+
+export const ZodSerializerDto = (dto: ZodDto | ZodSchema) =>
+  SetMetadata(ZodSerializerDtoOptions, dto)
+
+@Injectable()
+export class ZodSerializerInterceptor implements NestInterceptor {
+  constructor(@Inject(REFLECTOR) protected readonly reflector: any) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const responseSchema = this.getContextResponseSchema(context)
+
+    return next.handle().pipe(
+      map((res: object | object[]) => {
+        if (!responseSchema) return res
+        if (typeof res !== 'object' || res instanceof StreamableFile) return res
+
+        return Array.isArray(res)
+          ? res.map((item) => validate(item, responseSchema))
+          : validate(res, responseSchema)
+      })
+    )
+  }
+
+  protected getContextResponseSchema(
+    context: ExecutionContext
+  ): ZodDto | ZodSchema | undefined {
+    return this.reflector.getAllAndOverride(ZodSerializerDtoOptions, [
+      context.getHandler(),
+      context.getClass(),
+    ])
+  }
+}


### PR DESCRIPTION
Hi @risenforces, found the need for a serializer interceptor similar to nestjs `ClassSerializerInterceptor` and thought to contribute to this repository!

For more context, please see #43 

If you think this is a nice feature to have, I will update the main README.md with usage instructions as well.

Usage is simple, all you have to do is define `@ZodSerializerDto(<zodDto or schema>)` on the controller / class level, and all responses must take the shape of the zod dto. Otherwise, a `ZodValidationException` will be thrown.